### PR TITLE
sobreposicao do header fix

### DIFF
--- a/public/assets/css/global/header.css
+++ b/public/assets/css/global/header.css
@@ -11,7 +11,7 @@
   top: 0;
   left: 0;
   background-color: rgba(127, 136, 132, 0.575);
-  z-index: 99999;
+  z-index: 99997;
 }
 
 .header-bg {


### PR DESCRIPTION
O header estava sobrepondo o poups de marcar consulta escondendo o botão de fechar o poups. Foi resolvido colondo um z-index menor.